### PR TITLE
Handle two OF_select when add a linked OF on CF

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## Version 1.0.1
+## Version 1.0
 
 ### Changed
 
-- FIX Fetch and display the OF select value when link an OF on CF (OF select on Dolibarr form AND OF select on Quicksupplier form)
+- FIX [2020-12-10] Fetch and display the OF select value when link an OF on CF (OF select on Dolibarr form AND OF select on Quicksupplier form)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,8 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+## Version 1.0.1
+
+### Changed
+
+- FIX Fetch and display the OF select value when link an OF on CF (OF select on Dolibarr form AND OF select on Quicksupplier form)

--- a/class/actions_quicksupplierprice.class.php
+++ b/class/actions_quicksupplierprice.class.php
@@ -216,6 +216,11 @@ class Actionsquicksupplierprice
                                 
                             ?>
                         }
+
+                        if($("#options_linked_of1").val() !== 0){
+                        	let secondOFSelectValue = $("#options_linked_of1").val();
+                        	$("#options_linked_of").val(secondOFSelectValue);
+						}
                         
                     });
 
@@ -318,7 +323,7 @@ console.log(data.nb);
 				$objectline = new CommandeFournisseurLigne($db);
 				$extrafieldsline = new ExtraFields($db);
 				$extralabelslines=$extrafieldsline->fetch_name_optionals_label($object->table_element_line);
-				print $objectline->showOptionals($extrafieldsline, 'edit', array('style'=>'', 'colspan'=>6), '', '', empty($conf->global->MAIN_EXTRAFIELDS_IN_ONE_TD)?0:1);
+				print $objectline->showOptionals($extrafieldsline, 'edit', array('style'=>'', 'colspan'=>6), empty($conf->global->MAIN_EXTRAFIELDS_IN_ONE_TD)?'':1);
 		}
 
 		return 0; // or return 1 to replace standard code

--- a/core/modules/modquicksupplierprice.class.php
+++ b/core/modules/modquicksupplierprice.class.php
@@ -58,7 +58,7 @@ class modquicksupplierprice extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module quicksupplierprice";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.0';
+		$this->version = '1.0.1';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
# FIX

Fix d'un bug de récupération et d'affichage de l'OF lié. Seule la valeur d'un des deux select
(select du formulaire de base de Dolibarr et du formulaire disponible par le module Quicksupplierprice est prise en compte
dans les lignes de commande fournisseur)
