### PR TITLE
FIX : Bug with V13

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,5 +5,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- FIX : Fill the unit price to be used by the addline action of fourn/commande/card.php which has changed between V12 and V13 - *22/12/2021* - 1.1.3
 - FIX : Compatibility V13 - Add token renewal - *18/05/2021* - 1.1.2
 - FIX [2020-12-10] Fetch and display the OF select value when link an OF on CF (OF select on Dolibarr form AND OF select on Quicksupplier form)

--- a/class/actions_quicksupplierprice.class.php
+++ b/class/actions_quicksupplierprice.class.php
@@ -302,7 +302,9 @@ console.log(data.nb);
 
                                 $("#dp_desc").val( data.dp_desc );
                                 $("#idprodfournprice").replaceWith('<input type="hidden" name="idprodfournprice" id="idprodfournprice" value="'+data.retour+'" />' );
-                                $("#price_ht").val( $("#price_ht_qsp").val() / $("#qty_qsp").val() );
+                                if($("#qty_qsp").val() > 0) {
+                                    $("#price_ht").val( $("#price_ht_qsp").val() / $("#qty_qsp").val() );
+                                }
                                 $("#qty").val($("#qty_qsp").val());
 
                                 $("#addline").click(); 

--- a/class/actions_quicksupplierprice.class.php
+++ b/class/actions_quicksupplierprice.class.php
@@ -302,7 +302,7 @@ console.log(data.nb);
 
                                 $("#dp_desc").val( data.dp_desc );
                                 $("#idprodfournprice").replaceWith('<input type="hidden" name="idprodfournprice" id="idprodfournprice" value="'+data.retour+'" />' );
-
+                                $("#price_ht").val( $("#price_ht_qsp").val() / $("#qty_qsp").val() );
                                 $("#qty").val($("#qty_qsp").val());
 
                                 $("#addline").click(); 

--- a/core/modules/modquicksupplierprice.class.php
+++ b/core/modules/modquicksupplierprice.class.php
@@ -58,7 +58,7 @@ class modquicksupplierprice extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module quicksupplierprice";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.2';
+		$this->version = '1.1.3';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
# FIX

Lorsque l'on ajoutait un nouvelle ligne avec un prix fournisseur à la volée, le montant Total HT n'était pas récupéré.
On obtenait donc une ligne supplémentaire avec les montants à 0€.
Le problème vient du fait que l'action 'addline' de fourn/commande/card.php a changé entre la V12 et la V13