### PR TITLE
move qsp block after addline form in Dol 14.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- FIX : UX Changes between DOL 13.0 and 14.0 so we pull the qsp form under addline tpl - *02/05/2022* - 1.1.5
 - FIX : tvatx must not be converted to int, because it can have decimals and specific tva code - *30/03/2022* - 1.1.4
 - FIX : Fill the unit price to be used by the addline action of fourn/commande/card.php which has changed between V12 and V13 - *22/12/2021* - 1.1.3
 - FIX : Compatibility V13 - Add token renewal - *18/05/2021* - 1.1.2

--- a/class/actions_quicksupplierprice.class.php
+++ b/class/actions_quicksupplierprice.class.php
@@ -331,4 +331,37 @@ console.log(data.nb);
 		return 0; // or return 1 to replace standard code
 
 	}
+
+	function addMoreActionsButtons($parameters, &$object, &$action, $hookmanager)
+	{
+		$TContext = explode(':', $parameters['context']);
+
+		if (in_array('ordersuppliercard', $TContext) || in_array('invoicesuppliercard', $TContext))
+		{
+			if(version_compare(DOL_VERSION,'13.0.0') > 0)
+			{
+			?>
+			<script>
+				$(document).ready(function(){ 
+					let qsp_tr = $("#search_idprod_qsp").closest("tr");
+					let qsp_title = qsp_tr.prev();
+					let qsp_script = qsp_title.next();
+					let qsp_optionnals = qsp_script.next();
+
+					let afterBlock = "#trlinefordates";
+					if ($(afterBlock).length == 0) afterBlock = ".liste_titre_create";
+					$(afterBlock).after(qsp_optionnals);
+					$(afterBlock).after(qsp_script);
+					$(afterBlock).after(qsp_tr);
+					$(afterBlock).after(qsp_title);
+				});
+				
+			</script>
+			<?php
+			}
+		}
+
+		return 0;
+	}
+
 }

--- a/core/modules/modquicksupplierprice.class.php
+++ b/core/modules/modquicksupplierprice.class.php
@@ -58,7 +58,7 @@ class modquicksupplierprice extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = "Description of module quicksupplierprice";
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.1.4';
+		$this->version = '1.1.5';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
FIX : UX Changes between DOL 13.0 and 14.0 so we pull the qsp form under addline tpl